### PR TITLE
Feat: Add DB Transaction for scraping [WIP]

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -37,7 +37,7 @@ export async function createContainer(
 
   container.register({
     config: asValue(config),
-    db: asClass(DB),
+    db: asClass(DB).singleton(),
     router: asFunction(createRouter).singleton(),
     app: asFunction(createApp).singleton(),
     scheduler: asClass(SchedulerService).singleton(),

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,13 +3,17 @@ import type { Config } from "./config";
 
 export default class DB {
   private config: Config;
+  private client?: typeof mongoose;
   constructor({ config }: { config: Config }) {
     this.config = config;
   }
 
   async connect() {
     try {
-      await mongoose.connect(this.config.MONGO_URI, this.config.dbOptions);
+      this.client = await mongoose.connect(
+        this.config.MONGO_URI,
+        this.config.dbOptions,
+      );
 
       mongoose.set("debug", process.env.NODE_ENV !== "production");
     } catch (e) {
@@ -26,5 +30,10 @@ export default class DB {
         e instanceof Error ? e.message : "Unknown error",
       );
     }
+  }
+
+  startSession() {
+    if (!this.client) throw new Error("Moongoose can not initialized");
+    return this.client.startSession();
   }
 }


### PR DESCRIPTION
If any operation within the scrape fails, this pr ensures the elimination of possible inconsistent or duplicate data.

Important note: Mongodb transactions only work in replication sets. Necessary docker setup should be initialized.